### PR TITLE
Updated query `getJobs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,9 +463,7 @@ query getJobs {
             }
           }           
           payload
-          log {
-            uri
-          }
+          taskOutput
         }
       }
     }


### PR DESCRIPTION
Modified query to reference `taskOutput` instead of log for V2F engine compatibility.